### PR TITLE
ubuntu ve Centos aliasları kopyalar

### DIFF
--- a/roles/00_quick_env_info/tasks/aliaslist.yaml
+++ b/roles/00_quick_env_info/tasks/aliaslist.yaml
@@ -1,0 +1,14 @@
+---
+- name: Aliasları listeyelerek home dizin altına bir dosyaya yazar
+  hosts: erkantest
+#  become_user: root
+#  become_method: su
+  become: yes
+  gather_facts: True
+  tasks:
+     - name: alias listeleme ve kayıt
+#       shell: alias >> /home/osboxes/aliaslar.txt
+       raw: "bash -ic alias >/home/osboxes/aliaslar.txt"  # debug yapmak isterseniz >>/home/osboxes/aliaslar.txt ifadesini kaldırıp debug ve altındaki satırdan yorum işaretini kaldırınız.
+       register: command_output
+#     - debug:
+#         var: command_output.stdout_lines


### PR DESCRIPTION
ubuntu ve Centos aliasları home kopyalar. aliaslar.txt isimli bir dosya oluşturur. Her çalıştırıldığında dosyanın içi yeniden yazılır.Üzerine ekleme yapılmaz.